### PR TITLE
Updates djwt to (still temporary) version that works with Deno 1.6.1

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -3,22 +3,22 @@ export {
   assertThrowsAsync,
 } from "https://deno.land/std@0.74.0/testing/asserts.ts";
 
-export { validateJwt } from "https://deno.land/x/djwt@v1.7/validate.ts";
+export { validateJwt } from "https://raw.githubusercontent.com/asantos00/djwt/update-god_crypto-on-v1.7/validate.ts";
 export type {
   JwtObject,
   JwtValidation,
   Validation,
-} from "https://deno.land/x/djwt@v1.7/validate.ts";
+} from "https://raw.githubusercontent.com/asantos00/djwt/update-god_crypto-on-v1.7/validate.ts";
 
 export {
   makeJwt,
   setExpiration,
-} from "https://deno.land/x/djwt@v1.7/create.ts";
+} from "https://raw.githubusercontent.com/asantos00/djwt/update-god_crypto-on-v1.7/create.ts";
 export type {
   Algorithm,
   Jose,
   Payload,
-} from "https://deno.land/x/djwt@v1.7/create.ts";
+} from "https://raw.githubusercontent.com/asantos00/djwt/update-god_crypto-on-v1.7/create.ts";
 
 export { createHttpError } from "https://deno.land/x/oak@v6.3.1/httpError.ts";
 

--- a/deps.ts
+++ b/deps.ts
@@ -2,25 +2,30 @@ export {
   assert,
   assertThrowsAsync,
 } from "https://deno.land/std@0.74.0/testing/asserts.ts";
-export {
+
+export { validateJwt } from "https://deno.land/x/djwt@v1.7/validate.ts";
+export type {
   JwtObject,
   JwtValidation,
-  validateJwt,
   Validation,
 } from "https://deno.land/x/djwt@v1.7/validate.ts";
+
 export {
-  Algorithm,
-  Jose,
   makeJwt,
-  Payload,
   setExpiration,
 } from "https://deno.land/x/djwt@v1.7/create.ts";
+export type {
+  Algorithm,
+  Jose,
+  Payload,
+} from "https://deno.land/x/djwt@v1.7/create.ts";
+
 export { createHttpError } from "https://deno.land/x/oak@v6.3.1/httpError.ts";
-export {
-  Context,
+
+export type {
   HTTPMethods,
   Middleware,
   RouterContext,
   RouterMiddleware,
-  Status,
 } from "https://deno.land/x/oak@v6.3.1/mod.ts";
+export { Context, Status } from "https://deno.land/x/oak@v6.3.1/mod.ts";


### PR DESCRIPTION
With the 1.5.0 update of Deno, the --isolatedModules was added by default (https://github.com/denoland/deno/releases/tag/v1.5.0), causing a breaking change. This breaks whoever is using this module on versions >1.5.

It happens that this module was based on djwt@1.7, which then based itself on a specific commit on god_crypto. The commit on the latter had a few problems with abstract async methods that still give warnings and break the applications running Deno. 

djwt has been updated, but after 1.7 it drastically changed its API. These API changes will cause (from my understanding) many changes on this module's (oak-middleware-jwt) API.

This PR adds the export types for type re-exporting (that are now required) and also bases itself on a version of djwt that works (a PR of mine that updated god_crypto). After this everything should work just fine while keeping the API.

If you want to refactor this module to use the new API from djwt, I'm also happy to help, let me know what I can do.

