### PR TITLE
Update djwt to version 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  DENO_VERSION: 1.6.0
+  DENO_VERSION: 1.6.3
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  DENO_VERSION: 1.4.6
+  DENO_VERSION: 1.6.0
 
 on:
   push:
@@ -21,9 +21,9 @@ jobs:
         uses: actions/checkout@master
       - name: Install deno
         uses: denolib/setup-deno@master
-        with: 
+        with:
           deno-version: ${{env.DENO_VERSION}}
       - name: Check formatting
         run: deno fmt --check
       - name: Run tests
-        run: deno test
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 test:
-	deno test --allow-net="localhost:9876"
+	deno test --allow-net="localhost"
 fmt:
 	deno fmt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 test:
-	deno test
+	deno test --allow-net="localhost:9876"
 fmt:
 	deno fmt

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Oak middleware for JWT
 
 ## Options
 
-* secret: string; // See the djwt module for Validation options
+* key: string; // See the djwt module for Validation options
 * algorithm: AlgorithmInput ; // See the djwt module for Validation options
 * customMessages?: ErrorMessages; // Custom error messages
 * ignorePatterns?: Array<IgnorePattern>; // Pattern to ignore e.g. `/authenticate`, can be a RegExp, Pattern object or string. When passing a string, the string will be matched with the path `===`
@@ -101,8 +101,6 @@ const onSuccess = (ctx, payload: Payload) => {
   console.log(payload.userId)
 }
 ```
-
-- Change property `key` to `secret`, as the former is deprecated.
 
 - The expired token bug was fixed. This module will now throw an error (and call `onFailure` callback) if the token sent is expired. Can cause problems in implementations that weren't expecting that
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ app.use(jwtMiddleware<Middleware>({key: "foo", algorithm }))
 
 - Change the onFailure and onSuccess callbacks.
   - `onSuccess` gets an object of type `Payload` as a second argument (check https://github.com/timonson/djwt#decode)
-  - `onFailure` gets an object of type `Error` as a second argument
+  - `onFailure` gets an object of type `Error` as a second argument, should return `true` if the error should be thrown instead of returning as a response.
 
 ```ts
 const onFailure = (ctx, error: Error) => {

--- a/deps.ts
+++ b/deps.ts
@@ -2,7 +2,7 @@ export {
   assert,
   assertEquals,
   assertThrowsAsync,
-} from "https://deno.land/std@0.74.0/testing/asserts.ts";
+} from "https://deno.land/std@0.82.0/testing/asserts.ts";
 
 export type { Payload } from "https://deno.land/x/djwt@v2.0/mod.ts";
 export type { AlgorithmInput } from "https://deno.land/x/djwt@v2.0/algorithm.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,6 @@
 export {
   assert,
+  assertEquals,
   assertThrowsAsync,
 } from "https://deno.land/std@0.74.0/testing/asserts.ts";
 
@@ -28,4 +29,8 @@ export type {
   RouterContext,
   RouterMiddleware,
 } from "https://deno.land/x/oak@v6.3.1/mod.ts";
-export { Context, Status } from "https://deno.land/x/oak@v6.3.1/mod.ts";
+export {
+  Application,
+  Context,
+  Status,
+} from "https://deno.land/x/oak@v6.3.1/mod.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -2,25 +2,30 @@ export {
   assert,
   assertThrowsAsync,
 } from "https://deno.land/std@0.74.0/testing/asserts.ts";
-export {
+
+export { validateJwt } from "https://deno.land/x/djwt@v1.7/validate.ts";
+export type {
   JwtObject,
   JwtValidation,
-  validateJwt,
   Validation,
 } from "https://deno.land/x/djwt@v1.7/validate.ts";
+
 export {
-  Algorithm,
-  Jose,
   makeJwt,
-  Payload,
   setExpiration,
 } from "https://deno.land/x/djwt@v1.7/create.ts";
+export type {
+  Algorithm,
+  Jose,
+  Payload,
+} from "https://deno.land/x/djwt@v1.7/create.ts";
+
 export { createHttpError } from "https://deno.land/x/oak@v6.3.1/httpError.ts";
-export {
-  Context,
+
+export type {
   HTTPMethods,
   Middleware,
   RouterContext,
   RouterMiddleware,
-  Status,
 } from "https://deno.land/x/oak@v6.3.1/mod.ts";
+export { Context, Status } from "https://deno.land/x/oak@v6.3.1/mod.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -4,22 +4,13 @@ export {
   assertThrowsAsync,
 } from "https://deno.land/std@0.74.0/testing/asserts.ts";
 
-export { validateJwt } from "https://deno.land/x/djwt@v1.7/validate.ts";
-export type {
-  JwtObject,
-  JwtValidation,
-  Validation,
-} from "https://deno.land/x/djwt@v1.7/validate.ts";
-
+export type { Payload } from "https://deno.land/x/djwt@v2.0/mod.ts";
+export type { AlgorithmInput } from "https://deno.land/x/djwt@v2.0/algorithm.ts";
 export {
-  makeJwt,
-  setExpiration,
-} from "https://deno.land/x/djwt@v1.7/create.ts";
-export type {
-  Algorithm,
-  Jose,
-  Payload,
-} from "https://deno.land/x/djwt@v1.7/create.ts";
+  create,
+  getNumericDate,
+  verify,
+} from "https://deno.land/x/djwt@v2.0/mod.ts";
 
 export { createHttpError } from "https://deno.land/x/oak@v6.3.1/httpError.ts";
 

--- a/integration.test.ts
+++ b/integration.test.ts
@@ -27,7 +27,7 @@ const createApplicationAndClient = () => {
   app.use(
     jwtMiddleware<Middleware>({
       algorithm: ALGORITHM,
-      secret: SECRET,
+      key: SECRET,
     }),
   );
 

--- a/integration.test.ts
+++ b/integration.test.ts
@@ -1,13 +1,11 @@
 import {
   Application,
-  assert,
   assertEquals,
-  Jose,
   makeJwt,
   Middleware,
   setExpiration,
 } from "./deps.ts";
-import { jwtMiddleware, JwtMiddlewareOptions } from "./mod.ts";
+import { jwtMiddleware } from "./mod.ts";
 
 const SECRET = "some-secret";
 const ALGORITHM = "HS512";
@@ -22,7 +20,7 @@ const getJWT = ({ expirationDate }: { expirationDate?: Date } = {}) => {
         alg: ALGORITHM,
       },
       payload: {
-        iat: setExpiration(expirationDate || new Date()),
+        iat: setExpiration(new Date()),
         iss: "test",
       },
     },
@@ -108,7 +106,6 @@ const tests = [
       const headers = new Headers();
       headers.set("Authorization", `Bearer ${await getJWT()}`);
 
-      console.log(await getJWT());
       const response = await client.request({ headers });
 
       assertEquals(response.status, 200);
@@ -126,7 +123,6 @@ const tests = [
       const headers = new Headers();
       headers.set("Authorization", `Bearer ${INVALID_JWT}`);
 
-      console.log(await getJWT());
       const response = await client.request({ headers });
 
       assertEquals(response.status, 401);
@@ -135,32 +131,31 @@ const tests = [
       controller.abort();
     },
   },
-  {
-    name: "failure with expired token",
-    async fn() {
-      const { controller, client, listen } = createApplicationAndClient();
-      listen();
+  // {
+  //   name: "failure with expired token",
+  //   async fn() {
+  //     const { controller, client, listen } = createApplicationAndClient();
+  //     listen();
 
-      const headers = new Headers();
-      const expiredJwt = await getJWT({
-        expirationDate: new Date(2000, 0, 1),
-      });
+  //     const headers = new Headers();
+  //     const expiredJwt = await getJWT({
+  //       expirationDate: new Date(2000, 0, 1),
+  //     });
 
-      console.log(expiredJwt);
+  //     headers.set("Authorization", `Bearer ${expiredJwt}`);
 
-      headers.set("Authorization", `Bearer ${expiredJwt}`);
+  //     const response = await client.request({ headers });
 
-      const response = await client.request({ headers });
+  //     assertEquals(response.status, 401);
+  //     assertEquals(await response.text(), "Authentication failed");
 
-      assertEquals(response.status, 401);
-      assertEquals(await response.text(), "Authentication failed");
-
-      controller.abort();
-    },
-  },
+  //     controller.abort();
+  //   },
+  // },
 ];
 
 for await (const test of tests) {
+  test.name = `integration: ${test.name}`;
   Deno.test(test);
 }
 

--- a/integration.test.ts
+++ b/integration.test.ts
@@ -13,7 +13,7 @@ const ALGORITHM: AlgorithmInput = "HS512";
 const INVALID_JWT =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
 
-const getJWT = ({ expirationDate }: { expirationDate?: number } = {}) => {
+const getJWT = ({ expirationDate }: { expirationDate?: Date } = {}) => {
   return create({ alg: ALGORITHM, typ: "jwt" }, {
     exp: getNumericDate(expirationDate || 60 * 60),
   }, SECRET);
@@ -124,27 +124,27 @@ const tests = [
       controller.abort();
     },
   },
-  // {
-  //   name: "failure with expired token",
-  //   async fn() {
-  //     const { controller, client, listen } = createApplicationAndClient();
-  //     listen();
+  {
+    name: "failure with expired token",
+    async fn() {
+      const { controller, client, listen } = createApplicationAndClient();
+      listen();
 
-  //     const headers = new Headers();
-  //     const expiredJwt = await getJWT({
-  //       expirationDate: new Date(2000, 0, 1),
-  //     });
+      const headers = new Headers();
+      const expiredJwt = await getJWT({
+        expirationDate: new Date(2000, 0, 0),
+      });
 
-  //     headers.set("Authorization", `Bearer ${expiredJwt}`);
+      headers.set("Authorization", `Bearer ${expiredJwt}`);
 
-  //     const response = await client.request({ headers });
+      const response = await client.request({ headers });
 
-  //     assertEquals(response.status, 401);
-  //     assertEquals(await response.text(), "Authentication failed");
+      assertEquals(response.status, 401);
+      assertEquals(await response.text(), "Authentication failed");
 
-  //     controller.abort();
-  //   },
-  // },
+      controller.abort();
+    },
+  },
 ];
 
 for await (const test of tests) {

--- a/integration.test.ts
+++ b/integration.test.ts
@@ -1,30 +1,22 @@
 import {
+  AlgorithmInput,
   Application,
   assertEquals,
-  makeJwt,
+  create,
+  getNumericDate,
   Middleware,
-  setExpiration,
 } from "./deps.ts";
 import { jwtMiddleware } from "./mod.ts";
 
 const SECRET = "some-secret";
-const ALGORITHM = "HS512";
+const ALGORITHM: AlgorithmInput = "HS512";
 const INVALID_JWT =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
 
-const getJWT = ({ expirationDate }: { expirationDate?: Date } = {}) => {
-  return makeJwt(
-    {
-      key: SECRET,
-      header: {
-        alg: ALGORITHM,
-      },
-      payload: {
-        iat: setExpiration(new Date()),
-        iss: "test",
-      },
-    },
-  );
+const getJWT = ({ expirationDate }: { expirationDate?: number } = {}) => {
+  return create({ alg: ALGORITHM, typ: "jwt" }, {
+    exp: getNumericDate(expirationDate || 60 * 60),
+  }, SECRET);
 };
 
 // Spawns an application with middleware instantiated
@@ -48,6 +40,7 @@ const createApplicationAndClient = () => {
     listen: () => {
       return app.listen({
         port: 9876,
+        hostname: "localhost",
         signal: controller.signal,
       });
     },

--- a/integration.test.ts
+++ b/integration.test.ts
@@ -1,0 +1,167 @@
+import {
+  Application,
+  assert,
+  assertEquals,
+  Jose,
+  makeJwt,
+  Middleware,
+  setExpiration,
+} from "./deps.ts";
+import { jwtMiddleware, JwtMiddlewareOptions } from "./mod.ts";
+
+const SECRET = "some-secret";
+const ALGORITHM = "HS512";
+const INVALID_JWT =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+const getJWT = ({ expirationDate }: { expirationDate?: Date } = {}) => {
+  return makeJwt(
+    {
+      key: SECRET,
+      header: {
+        alg: ALGORITHM,
+      },
+      payload: {
+        iat: setExpiration(expirationDate || new Date()),
+        iss: "test",
+      },
+    },
+  );
+};
+
+// Spawns an application with middleware instantiated
+const createApplicationAndClient = () => {
+  const controller = new AbortController();
+  const app = new Application();
+
+  app.use(
+    jwtMiddleware<Middleware>({
+      algorithm: ALGORITHM,
+      key: SECRET,
+    }),
+  );
+
+  app.use((ctx) => {
+    ctx.response.body = "hello-world";
+    ctx.response.status = 200;
+  });
+
+  return {
+    listen: () => {
+      return app.listen({
+        port: 9876,
+        signal: controller.signal,
+      });
+    },
+    controller,
+    client: {
+      request: (options: RequestInit) => {
+        return fetch("http://localhost:9876", options);
+      },
+    },
+  };
+};
+
+const tests = [
+  {
+    name: "error with invalid Authorization",
+    async fn() {
+      const { controller, client, listen } = createApplicationAndClient();
+      listen();
+
+      const headers = new Headers();
+      headers.set("Authorization", "Noth");
+
+      const response = await client.request({ headers });
+
+      assertEquals(response.status, 401);
+      assertEquals(response.statusText, "Unauthorized");
+      assertEquals(await response.text(), "Authentication failed");
+
+      controller.abort();
+    },
+  },
+  {
+    name: "error with invalid Bearer",
+    async fn() {
+      const { controller, client, listen } = createApplicationAndClient();
+      listen();
+
+      const headers = new Headers();
+      headers.set("Authorization", "Bearer 123");
+
+      const response = await client.request({ headers });
+
+      assertEquals(response.status, 401);
+      assertEquals(response.statusText, "Unauthorized");
+      assertEquals(await response.text(), "Authentication failed");
+
+      controller.abort();
+    },
+  },
+  {
+    name: "success with valid token",
+    async fn() {
+      const { controller, client, listen } = createApplicationAndClient();
+      listen();
+
+      const headers = new Headers();
+      headers.set("Authorization", `Bearer ${await getJWT()}`);
+
+      console.log(await getJWT());
+      const response = await client.request({ headers });
+
+      assertEquals(response.status, 200);
+      assertEquals(await response.text(), "hello-world");
+
+      controller.abort();
+    },
+  },
+  {
+    name: "failure with invalid token",
+    async fn() {
+      const { controller, client, listen } = createApplicationAndClient();
+      listen();
+
+      const headers = new Headers();
+      headers.set("Authorization", `Bearer ${INVALID_JWT}`);
+
+      console.log(await getJWT());
+      const response = await client.request({ headers });
+
+      assertEquals(response.status, 401);
+      assertEquals(await response.text(), "Authentication failed");
+
+      controller.abort();
+    },
+  },
+  {
+    name: "failure with expired token",
+    async fn() {
+      const { controller, client, listen } = createApplicationAndClient();
+      listen();
+
+      const headers = new Headers();
+      const expiredJwt = await getJWT({
+        expirationDate: new Date(2000, 0, 1),
+      });
+
+      console.log(expiredJwt);
+
+      headers.set("Authorization", `Bearer ${expiredJwt}`);
+
+      const response = await client.request({ headers });
+
+      assertEquals(response.status, 401);
+      assertEquals(await response.text(), "Authentication failed");
+
+      controller.abort();
+    },
+  },
+];
+
+for await (const test of tests) {
+  Deno.test(test);
+}
+
+export {};

--- a/src/jwtMiddleware.ts
+++ b/src/jwtMiddleware.ts
@@ -147,8 +147,10 @@ export const jwtMiddleware = <
       critHandlers,
     });
 
-    if (!validatedJwt.isValid) {
+    // Invalid or expired token
+    if (validatedJwt.isExpired || !validatedJwt.isValid) {
       await onUnauthorized(validatedJwt);
+
       return;
     }
 

--- a/src/jwtMiddleware.ts
+++ b/src/jwtMiddleware.ts
@@ -29,7 +29,7 @@ export interface JwtMiddlewareOptions extends Partial<Validation> {
   customMessages?: ErrorMessages;
 
   /** Pattern to ignore e.g. `/authenticate`, can be a RegExp, Pattern object or string.
-   * 
+   *
    * When passing a string, the string will be matched with the path `===`.
    */
   ignorePatterns?: Array<IgnorePattern>;
@@ -38,7 +38,7 @@ export interface JwtMiddlewareOptions extends Partial<Validation> {
   onSuccess?: OnSuccessHandler;
 
   /** Optional callback for unsuccessfull validation, passes the Context and JwtValidation if the JWT is present in the header.
-	 * 
+	 *
 	 * When not used, will throw HTTPError using custom (or default) messages.
 	 * If you want the failure to be ignored and to call the next middleware, return true.
 	 */
@@ -83,6 +83,12 @@ const ignorePath = <T extends Context | RouterContext>(
   return false;
 };
 
+/*
+  Errors:
+  1. No authorization header
+  2. Invalid authorization header
+  3. Authorization header that is not Bearer + Token
+*/
 export const jwtMiddleware = <
   T extends RouterMiddleware | Middleware = Middleware,
 >({
@@ -91,49 +97,62 @@ export const jwtMiddleware = <
   critHandlers,
   customMessages = {},
   ignorePatterns,
-  onSuccess,
-  onFailure,
+  onSuccess = () => {},
+  onFailure = () => true,
 }: JwtMiddlewareOptions): T => {
   Object.assign(customMessages, errorMessages);
 
   const core: RouterMiddleware = async (ctx, next) => {
-    if (!ignorePatterns || !ignorePath(ctx, ignorePatterns)) {
-      let isUnauthorized = true;
-      let validatedJwt;
-      if (ctx.request.headers.has("Authorization")) {
-        const authHeader = ctx.request.headers.get("Authorization")!;
-
-        if (authHeader.startsWith("Bearer ") && authHeader.length > 7) {
-          const jwt = authHeader.slice(7);
-
-          validatedJwt = await validateJwt({
-            jwt,
-            key,
-            algorithm,
-            critHandlers,
-          });
-
-          if (validatedJwt.isValid) {
-            isUnauthorized = false;
-            onSuccess && onSuccess(ctx, validatedJwt);
-          }
-        }
+    const onUnauthorized = async (
+      validatedJwt?: JwtValidation,
+    ) => {
+      const shouldThrow = onFailure(ctx, validatedJwt);
+      if (shouldThrow) {
+        ctx.throw(
+          Status.Unauthorized,
+          customMessages?.ERROR_INVALID_AUTH,
+        );
       }
 
-      if (isUnauthorized) {
-        if (onFailure) {
-          const ignoreFailure = onFailure(ctx, validatedJwt);
+      await next();
+    };
 
-          if (!ignoreFailure) return;
-        } else {
-          ctx.throw(
-            Status.Unauthorized,
-            customMessages?.ERROR_INVALID_AUTH,
-          );
-        }
-      }
+    // If request matches ignore, call next early
+    if (ignorePatterns && ignorePath(ctx, ignorePatterns)) {
+      await next();
+
+      return;
     }
 
+    // No Authorization header
+    if (!ctx.request.headers.has("Authorization")) {
+      await onUnauthorized();
+
+      return;
+    }
+
+    // Authorization header has no Bearer or no token
+    const authHeader = ctx.request.headers.get("Authorization")!;
+    if (!authHeader.startsWith("Bearer ") || authHeader.length <= 7) {
+      await onUnauthorized();
+
+      return;
+    }
+
+    const jwt = authHeader.slice(7);
+    const validatedJwt = await validateJwt({
+      jwt,
+      key,
+      algorithm,
+      critHandlers,
+    });
+
+    if (!validatedJwt.isValid) {
+      await onUnauthorized(validatedJwt);
+      return;
+    }
+
+    onSuccess(ctx, validatedJwt);
     await next();
   };
 

--- a/test.ts
+++ b/test.ts
@@ -191,6 +191,49 @@ const tests = [
       assert(true);
     },
   },
+  {
+    name: "onSuccess is not called on invalid jwt",
+    async fn() {
+      const mw = jwtMiddleware({
+        ...jwtOptions,
+        onSuccess: () => {
+          assert(false, "onSuccess is not called");
+        },
+      });
+
+      assertThrowsAsync(
+        async () =>
+          await mw(
+            mockContext(
+              "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+            ),
+            mockNext,
+          ),
+        undefined,
+        "Authentication failed",
+      );
+    },
+  },
+  {
+    name: "onFailure is called",
+    async fn() {
+      const mw = jwtMiddleware({
+        ...jwtOptions,
+        onFailure: () => {
+          assert(true, "onFailure is called");
+
+          return false;
+        },
+      });
+
+      await mw(
+        mockContext(
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+        ),
+        mockNext,
+      );
+    },
+  },
 ];
 
 for await (const test of tests) {

--- a/test.ts
+++ b/test.ts
@@ -63,7 +63,7 @@ const tests = [
     },
   },
   {
-    name: "Failure with expiretd token",
+    name: "Failure with expired token",
     async fn() {
       const mockJwt = await create(
         { alg: ALGORITHM, typ: "jwt" },

--- a/test.ts
+++ b/test.ts
@@ -13,7 +13,7 @@ import { jwtMiddleware, JwtMiddlewareOptions } from "./mod.ts";
 const SECRET = "some-secret";
 const ALGORITHM: AlgorithmInput = "HS512";
 const jwtOptions = {
-  secret: SECRET,
+  key: SECRET,
   algorithm: ALGORITHM,
 };
 

--- a/test.ts
+++ b/test.ts
@@ -4,6 +4,7 @@ import {
   assertThrowsAsync,
   create,
   createHttpError,
+  getNumericDate,
   Payload,
   RouterContext,
 } from "./deps.ts";
@@ -37,35 +38,6 @@ const mockNext = () => {
 };
 
 const tests = [
-  // {
-  //   name: "expired token",
-  //   async fn() {
-  //     let jwtObj: any = initJwtObj();
-
-  //     const mockJwt = await makeJwt(
-  //       {
-  //         key: SECRET,
-  //         header,
-  //         payload: {
-  //           ...payload,
-  //           iat: setExpiration(new Date(2000, 0, 1)),
-  //         },
-  //       },
-  //     );
-
-  //     const mw = jwtMiddleware(Object.assign({}, jwtOptions, {
-  //       onSuccess: (ctx: any, jwt: any) => {
-  //         jwtObj = jwt;
-  //       },
-  //     }));
-
-  //     assertThrowsAsync(
-  //       async () => await mw(mockContext(mockJwt), mockNext),
-  //       undefined,
-  //       "Authentication failed",
-  //     );
-  //   },
-  // },
   {
     name: "Success",
     async fn() {
@@ -88,6 +60,24 @@ const tests = [
       await mw(mockContext(mockJwt), mockNext);
 
       assert(jwtObj.test === payload.test);
+    },
+  },
+  {
+    name: "Failure with expiretd token",
+    async fn() {
+      const mockJwt = await create(
+        { alg: ALGORITHM, typ: "jwt" },
+        { exp: getNumericDate(new Date(2000, 1, 0)) },
+        SECRET,
+      );
+
+      const mw = jwtMiddleware(jwtOptions);
+
+      assertThrowsAsync(
+        async () => await mw(mockContext(mockJwt), mockNext),
+        undefined,
+        "Authentication failed",
+      );
     },
   },
   {

--- a/test.ts
+++ b/test.ts
@@ -20,7 +20,7 @@ const jwtOptions: JwtMiddlewareOptions = {
 };
 
 const payload = {
-  iat: setExpiration(new Date().getTime()),
+  iat: setExpiration(new Date()),
   iss: "test",
 };
 
@@ -47,6 +47,35 @@ const mockNext = () => {
 const initJwtObj = (): JwtObject => ({}) as JwtObject;
 
 const tests = [
+  {
+    name: "expired token",
+    async fn() {
+      let jwtObj: any = initJwtObj();
+
+      const mockJwt = await makeJwt(
+        {
+          key: SECRET,
+          header,
+          payload: {
+            ...payload,
+            iat: setExpiration(new Date(2000, 0, 1)),
+          },
+        },
+      );
+
+      const mw = jwtMiddleware(Object.assign({}, jwtOptions, {
+        onSuccess: (ctx: any, jwt: any) => {
+          jwtObj = jwt;
+        },
+      }));
+
+      assertThrowsAsync(
+        async () => await mw(mockContext(mockJwt), mockNext),
+        undefined,
+        "Authentication failed",
+      );
+    },
+  },
   {
     name: "Success",
     async fn() {

--- a/test.ts
+++ b/test.ts
@@ -12,7 +12,7 @@ import { jwtMiddleware, JwtMiddlewareOptions } from "./mod.ts";
 
 const SECRET = "some-secret";
 const ALGORITHM: AlgorithmInput = "HS512";
-const jwtOptions = {
+const jwtOptions: JwtMiddlewareOptions = {
   key: SECRET,
   algorithm: ALGORITHM,
 };
@@ -76,7 +76,7 @@ const tests = [
       assertThrowsAsync(
         async () => await mw(mockContext(mockJwt), mockNext),
         undefined,
-        "Authentication failed",
+        "The jwt is expired.",
       );
     },
   },
@@ -118,7 +118,7 @@ const tests = [
             mockNext,
           ),
         undefined,
-        "Authentication failed",
+        "The jwt's algorithm does not match the specified algorithm 'HS512'.",
       );
     },
   },
@@ -226,7 +226,7 @@ const tests = [
             mockNext,
           ),
         undefined,
-        "Authentication failed",
+        "The jwt's algorithm does not match the specified algorithm 'HS512'.",
       );
     },
   },

--- a/test.ts
+++ b/test.ts
@@ -47,35 +47,35 @@ const mockNext = () => {
 const initJwtObj = (): JwtObject => ({}) as JwtObject;
 
 const tests = [
-  {
-    name: "expired token",
-    async fn() {
-      let jwtObj: any = initJwtObj();
+  // {
+  //   name: "expired token",
+  //   async fn() {
+  //     let jwtObj: any = initJwtObj();
 
-      const mockJwt = await makeJwt(
-        {
-          key: SECRET,
-          header,
-          payload: {
-            ...payload,
-            iat: setExpiration(new Date(2000, 0, 1)),
-          },
-        },
-      );
+  //     const mockJwt = await makeJwt(
+  //       {
+  //         key: SECRET,
+  //         header,
+  //         payload: {
+  //           ...payload,
+  //           iat: setExpiration(new Date(2000, 0, 1)),
+  //         },
+  //       },
+  //     );
 
-      const mw = jwtMiddleware(Object.assign({}, jwtOptions, {
-        onSuccess: (ctx: any, jwt: any) => {
-          jwtObj = jwt;
-        },
-      }));
+  //     const mw = jwtMiddleware(Object.assign({}, jwtOptions, {
+  //       onSuccess: (ctx: any, jwt: any) => {
+  //         jwtObj = jwt;
+  //       },
+  //     }));
 
-      assertThrowsAsync(
-        async () => await mw(mockContext(mockJwt), mockNext),
-        undefined,
-        "Authentication failed",
-      );
-    },
-  },
+  //     assertThrowsAsync(
+  //       async () => await mw(mockContext(mockJwt), mockNext),
+  //       undefined,
+  //       "Authentication failed",
+  //     );
+  //   },
+  // },
   {
     name: "Success",
     async fn() {


### PR DESCRIPTION
This PR updates `djwt` to version 2.0. Making it work flawlessly with the current deno version (1.6.0)

## Breaking changes
- onFailure and onSuccess callbacks now get an `Error` or a `Payload` (from `djwt`) respectively
- Middleware now receives an `AlgorithmInput` instead of `Algorithm` (exported from `djwt`)

## New exports from `mod.ts`
- `Payload` - the value injected in `onSuccess` callback

## Major changes:
- Refactor middleware method to (try) to make error cases a little more clear, also tried to avoid mutation (and variables like `isAuthorized` and so on)
- Proxy errors from `djwt` to `onFailure` callback to more comprehensive errors
- Adds integration tests that spawn an instance of `oak` with the middleware and run tests against it 
- Adds unit tests for `onSuccess` and `onFailure`
- Github action needs to be changed to run `make test` instead of `deno test`, so that it includes the new permissions needed for the integration tests.
- Fixes a "bug" (please confirm if it's actually a bug) where expired tokens weren't making authentication fail.

I hope I can help you with this and we can move this forward, let me know if there's something more we can do!